### PR TITLE
исправил parsing error при запуске

### DIFF
--- a/SiriusProject/SiriusProject/Networking/APIService.swift
+++ b/SiriusProject/SiriusProject/Networking/APIService.swift
@@ -64,7 +64,7 @@ class APIService: Service {
                     completion(nil, .serverError(detail))
                     return
                 }
-                
+
                 if T.self == Data.self {
                     completion(data as? T, nil)
                     return

--- a/SiriusProject/SiriusProject/Networking/APIService.swift
+++ b/SiriusProject/SiriusProject/Networking/APIService.swift
@@ -64,6 +64,11 @@ class APIService: Service {
                     completion(nil, .serverError(detail))
                     return
                 }
+                
+                if T.self == Data.self {
+                    completion(data as? T, nil)
+                    return
+                }
 
                 let result = try JSONDecoder().decode(T.self, from: data)
                 completion(result, nil)

--- a/SiriusProject/SiriusProject/Networking/NetworkManager.swift
+++ b/SiriusProject/SiriusProject/Networking/NetworkManager.swift
@@ -5,6 +5,8 @@
 //  Created by Андрей Степанов on 26.03.2025.
 //
 
+import Foundation
+
 struct NetworkManager: NetworkManagerProtocol {
     private let service: APIService
     let logging: Logging
@@ -196,13 +198,13 @@ struct NetworkManager: NetworkManagerProtocol {
             return
         }
 
-        service.makeRequest(with: request, respModel: Bool.self, logging: logging) { success, error in
+        service.makeRequest(with: request, respModel: Data.self, logging: logging) { response, error in
             if let error = error {
                 logging(error.localizedDescription)
                 completion(false)
                 return
             }
-            completion(success ?? false)
+            completion(response != nil)
         }
     }
 }


### PR DESCRIPTION
Из-за регистрации устройства для пушей, присылался log передачи, а NetworkManager ожидал Bool.
Поменял тип запроса на Data и добавил обработку Data в request.